### PR TITLE
Add re-usable schema for cluster name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [clustername](clustername/) v0.0.1 (2022-12-07)
+
+- Add clustername schema.
+
 ## [labelvalue](labelvalue/) v0.0.1 (2022-12-05)
 
-- Added labelvalue schema
+- Added labelvalue schema.
 
 ## [image](image/) v0.0.1 (2022-12-01)
 
-- Added image schema
+- Added image schema.

--- a/clustername/README.md
+++ b/clustername/README.md
@@ -1,0 +1,5 @@
+# Clustername
+
+Schema for the string property defining the name of a cluster.
+
+Cluster names are very restricted in terms of character set and length, as they are used in many different contexts, e. g. in DNS names.

--- a/clustername/v0.0.1.json
+++ b/clustername/v0.0.1.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://schema.giantswarm.io/clustername/v0.0.1",
+    "title": "Cluster name",
+    "type": "string",
+    "minLength": 5,
+    "maxLength": 10,
+    "pattern": "^[a-z0-9]{5,10}$",
+    "examples": [
+        "abc12",
+        "dev01azure"
+    ]
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1181

This PR adds a schema to be used for the cluster's name string property. The idea is to use it in all cluster app schemas.