### PR TITLE
Normalize schema in repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## All (2022-12-09)
+
+- Applied normalization.
+
 ## [clustername](clustername/) v0.0.1 (2022-12-07)
 
 - Add clustername schema.

--- a/clustername/v0.0.1.json
+++ b/clustername/v0.0.1.json
@@ -11,4 +11,3 @@
     "title": "Cluster name",
     "type": "string"
 }
-

--- a/clustername/v0.0.1.json
+++ b/clustername/v0.0.1.json
@@ -1,13 +1,14 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://schema.giantswarm.io/clustername/v0.0.1",
-    "title": "Cluster name",
-    "type": "string",
-    "minLength": 5,
-    "maxLength": 10,
-    "pattern": "^[a-z0-9]{5,10}$",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "examples": [
         "abc12",
         "dev01azure"
-    ]
+    ],
+    "maxLength": 10,
+    "minLength": 5,
+    "pattern": "^[a-z0-9]{5,10}$",
+    "title": "Cluster name",
+    "type": "string"
 }
+

--- a/image/v0.0.1.json
+++ b/image/v0.0.1.json
@@ -1,47 +1,48 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://schema.giantswarm.io/image/v0.0.1",
-    "title": "Schema for container images",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "description": "Useful for specifying a container image to use in a helm chart context.",
-    "type": "object",
     "properties": {
         "name": {
-            "type": "string",
-            "title": "Name",
             "description": "Image name, optionally prefixed by a namespace and a separator, excluding tag.",
             "examples": [
                 "redis",
                 "giantswarm/happa"
-            ]
-        },
-        "tag": {
-            "type": "string",
-            "title": "Tag",
-            "description": "Specifies the version of the image, without colon.",
-            "examples": [
-                "latest",
-                "v4.1.2-alpine"
-            ]
-        },
-        "registry": {
-            "type": "string",
-            "title": "Registry",
-            "description": "Name of the server to access the image from.",
-            "examples": [
-                "quay.io",
-                "hub.docker.com"
-            ]
+            ],
+            "title": "Name",
+            "type": "string"
         },
         "pullPolicy": {
-            "type": "string",
             "enum": [
                 "Always",
                 "IfNotPresent",
                 "Never"
-            ]
+            ],
+            "type": "string"
+        },
+        "registry": {
+            "description": "Name of the server to access the image from.",
+            "examples": [
+                "quay.io",
+                "hub.docker.com"
+            ],
+            "title": "Registry",
+            "type": "string"
+        },
+        "tag": {
+            "description": "Specifies the version of the image, without colon.",
+            "examples": [
+                "latest",
+                "v4.1.2-alpine"
+            ],
+            "title": "Tag",
+            "type": "string"
         }
     },
     "required": [
         "name"
-    ]
+    ],
+    "title": "Schema for container images",
+    "type": "object"
 }
+

--- a/image/v0.0.1.json
+++ b/image/v0.0.1.json
@@ -45,4 +45,3 @@
     "title": "Schema for container images",
     "type": "object"
 }
-

--- a/labelvalue/v0.0.1.json
+++ b/labelvalue/v0.0.1.json
@@ -1,13 +1,14 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://schema.giantswarm.io/labelvalue/v0.0.1",
-    "title": "Value of a Kubernetes resource label",
-    "type": "string",
-    "minLength": 0,
-    "maxLength": 63,
-    "pattern": "^[-a-zA-Z0-9_\\.]{0,63}$",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "examples": [
         "exampleValue",
         "Example_value.with_numbers-and.separators01"
-    ]
+    ],
+    "maxLength": 63,
+    "minLength": 0,
+    "pattern": "^[-a-zA-Z0-9_\\.]{0,63}$",
+    "title": "Value of a Kubernetes resource label",
+    "type": "string"
 }
+

--- a/labelvalue/v0.0.1.json
+++ b/labelvalue/v0.0.1.json
@@ -11,4 +11,3 @@
     "title": "Value of a Kubernetes resource label",
     "type": "string"
 }
-


### PR DESCRIPTION
### What does this PR do?

Normalized the currently existing schemas by running them through `schemalint normalize`.

### Any background context you can provide?

We want all our work schemas happening in a "normalized" way, so that white space and ordering of elements are not matter of changes. To get used to the normalized order and format, I'm applying this to our existing files.

Context: https://github.com/giantswarm/roadmap/issues/1733

### Are you meeting our versioning requirements?

- In general, all schema modifications are done by creating a new version and new file.

This however is an exception, as it does not modify the meaning of the files in any way.

- Changes that can lead to breaking validation (where the payload was valid with the previous version) require a **major** version bump.
- Non-breaking changes like additions should yield a new **minor** version.
- Only smallest changes should be published as **patch** version bump, e. g. a typo fix in a `title` or `description` field.

### Have you also followed these requirements?

- [ ] I have requested reviews from several teams.
- [x] I updated CHANGELOG.md.
- [x] I checked/maintained the README.md within the schema folder.
