### PR TITLE
Always run lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,8 +3,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - '**.json'
 
 jobs:
   lint:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Internal change (2022-12-12)
+
+- Modified CI to always eceture lint workflow.
+
 ## All (2022-12-09)
 
 - Applied normalization.


### PR DESCRIPTION
### What does this PR do?

This PR removes the path filter from the lint workflow, so that it is executed on every push.

So far it was only executed if the branch modified JSON files. However if the lint check is not running in every PR, it cannot be set as required. We want it to be required on the repo level.

### Any background context you can provide?

https://github.com/giantswarm/roadmap/issues/1733
