### PR TITLE
Add schema for Kubernetes node taint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [nodetaint](nodetaint/) v0.0.1 (2023-03-06)
+
+- Added nodetaint schema.
+
 ## Internal change (2022-12-12)
 
 - Modified CI to always eceture lint workflow.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The purpose is to simplify the building of schemas for [app](https://docs.giants
 
 - [labelvalue](labelvalue/): String to be used as a Kubernetes resource label value.
 
+- [nodetaint](nodetaint/): Kubernetes node taint.
+
 ## How to use
 
 Schema in this repository can be referenced from other schemas via out `schema.giantswarm.io` resource URLs. Example:

--- a/nodetaint/README.md
+++ b/nodetaint/README.md
@@ -1,0 +1,6 @@
+# Kubernetes node taint
+
+This schema allows defining a Kubernetes node taint as described in
+
+- https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/node-v1/#NodeSpec
+- https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/

--- a/nodetaint/v0.0.1.json
+++ b/nodetaint/v0.0.1.json
@@ -13,9 +13,9 @@
             "type": "string"
         },
         "key": {
+            "minLength": 1,
             "title": "Key",
-            "type": "string",
-            "minLength": 1
+            "type": "string"
         },
         "value": {
             "title": "Value",

--- a/nodetaint/v0.0.1.json
+++ b/nodetaint/v0.0.1.json
@@ -1,0 +1,30 @@
+{
+    "$id": "https://schema.giantswarm.io/nodetaint/v0.0.1",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "The node this taint is attached to has the specified effect on any pod that does not tolerate the taint.",
+    "properties": {
+        "effect": {
+            "enum": [
+                "NoSchedule",
+                "PreferNoSchedule",
+                "NoExecute"
+            ],
+            "title": "Effect",
+            "type": "string"
+        },
+        "key": {
+            "title": "Key",
+            "type": "string"
+        },
+        "value": {
+            "title": "Value",
+            "type": "string"
+        }
+    },
+    "required": [
+        "effect",
+        "key"
+    ],
+    "title": "Node taint",
+    "type": "object"
+}

--- a/nodetaint/v0.0.1.json
+++ b/nodetaint/v0.0.1.json
@@ -14,7 +14,8 @@
         },
         "key": {
             "title": "Key",
-            "type": "string"
+            "type": "string",
+            "minLength": 1
         },
         "value": {
             "title": "Value",


### PR DESCRIPTION
### What does this PR do?

Adds a "nodetaint" schema to specify a [Kubernetes node taint](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).

An almost identical schema is already used in two providers:

- [GCP](https://github.com/giantswarm/cluster-gcp/blob/v0.35.0/helm/cluster-gcp/values.schema.json#L231-L254) - difference: GCP defines `value` as required
- [Azure](https://github.com/giantswarm/cluster-azure/blob/v0.0.13/helm/cluster-azure/values.schema.json#L269-L293) - difference: Azure defines `value` as required

### Any background context you can provide?

The cluster-azure app schema already provides an almost identical schema. The idea is to make this available for all cluster apps.

### Have you also followed these requirements?

- [ ] I have requested reviews from several teams.
- [x] I updated CHANGELOG.md.
- [x] I checked/maintained the README.md within the schema folder.
