### PR TITLE
Add oidcconfig schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The purpose is to simplify the building of schemas for [app](https://docs.giants
 
 - [labelvalue](labelvalue/): String to be used as a Kubernetes resource label value.
 
+- [oidcconfig](oidcconfig/): OpenID Connect (OIDC) configuration.
+
 ## How to use
 
 Schema in this repository can be referenced from other schemas via out `schema.giantswarm.io` resource URLs. Example:

--- a/oidcconfig/README.md
+++ b/oidcconfig/README.md
@@ -1,0 +1,3 @@
+# OpenID Connect (OIDC) Confifguration
+
+The purpose of this schema is to specify OIDC authentication settings of a Kubernetes API server.

--- a/oidcconfig/v0.0.1.json
+++ b/oidcconfig/v0.0.1.json
@@ -8,7 +8,7 @@
             "type": "string"
         },
         "clientId": {
-            "description": "OIDC client identifier to identify with",
+            "description": "OIDC client identifier to identify with.",
             "title": "Client ID",
             "type": "string"
         },

--- a/oidcconfig/v0.0.1.json
+++ b/oidcconfig/v0.0.1.json
@@ -1,0 +1,45 @@
+{
+    "$id": "https://schema.giantswarm.io/oidcconfig/v0.0.1",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "caPem": {
+            "description": "Identity provider's CA certificate in PEM format.",
+            "title": "Certificate authority",
+            "type": "string"
+        },
+        "clientId": {
+            "description": "OIDC client identifier to identify with",
+            "title": "Client ID",
+            "type": "string"
+        },
+        "groupsClaim": {
+            "default": "groups",
+            "description": "Name of the identity token claim bearing the user's group memberships.",
+            "title": "Groups claim",
+            "type": "string"
+        },
+        "issuerUrl": {
+            "description": "URL of the provider which allows the API server to discover public signing keys, not including any path. Discovery URL without the '/.well-known/openid-configuration' part.",
+            "format": "uri",
+            "title": "Issuer URL",
+            "type": "string"
+        },
+        "usernameClaim": {
+            "default": "email",
+            "description": "Name of the identity token claim bearing the unique user identifier.",
+            "title": "Username claim",
+            "type": "string"
+        },
+        "usernamePrefix": {
+            "description": "Prefix prepended to username values to prevent clashes with existing names",
+            "title": "Username prefix",
+            "type": "string"
+        }
+    },
+    "required": [
+        "clientId",
+        "issuerUrl"
+    ],
+    "title": "OpenID Connect (OIDC) configuration",
+    "type": "object"
+}


### PR DESCRIPTION
### What does this PR do?

Add a schema for providing OIDC configuration for a Kubernetes API server.

Reference: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/

### Have you also followed these requirements?

- [ ] I have requested reviews from several teams.
- [ ] I updated CHANGELOG.md.
- [ ] I checked/maintained the README.md within the schema folder.
