### PR TITLE
Update schemalint version to v2.1.1

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Install schemalint
         env:
-          SCHEMALINT_VERSION: v0.7.0
+          SCHEMALINT_VERSION: v2.1.1
         run: |
           wget -q -O ${HOME}/schemalint.tar.gz https://github.com/giantswarm/schemalint/releases/download/${SCHEMALINT_VERSION}/schemalint-${SCHEMALINT_VERSION}-linux-amd64.tar.gz
           cd ${HOME} && tar xvzf schemalint.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-## Internal change (2022-12-12)
+## 2023-04-23
 
-- Modified CI to always eceture lint workflow.
+- CI/CD: Updated schemalint to version v2.1.1.
+
+## 2022-12-12
+
+- Modified CI to always execute lint workflow.
 
 ## All (2022-12-09)
 

--- a/clustername/v0.0.1.json
+++ b/clustername/v0.0.1.json
@@ -1,13 +1,13 @@
 {
     "$id": "https://schema.giantswarm.io/clustername/v0.0.1",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "string",
+    "title": "Cluster name",
     "examples": [
         "abc12",
         "dev01azure"
     ],
     "maxLength": 10,
     "minLength": 5,
-    "pattern": "^[a-z0-9]{5,10}$",
-    "title": "Cluster name",
-    "type": "string"
+    "pattern": "^[a-z0-9]{5,10}$"
 }

--- a/image/v0.0.1.json
+++ b/image/v0.0.1.json
@@ -1,47 +1,47 @@
 {
     "$id": "https://schema.giantswarm.io/image/v0.0.1",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Schema for container images",
     "description": "Useful for specifying a container image to use in a helm chart context.",
+    "required": [
+        "name"
+    ],
     "properties": {
         "name": {
+            "type": "string",
+            "title": "Name",
             "description": "Image name, optionally prefixed by a namespace and a separator, excluding tag.",
             "examples": [
                 "redis",
                 "giantswarm/happa"
-            ],
-            "title": "Name",
-            "type": "string"
+            ]
         },
         "pullPolicy": {
+            "type": "string",
             "enum": [
                 "Always",
                 "IfNotPresent",
                 "Never"
-            ],
-            "type": "string"
+            ]
         },
         "registry": {
+            "type": "string",
+            "title": "Registry",
             "description": "Name of the server to access the image from.",
             "examples": [
                 "quay.io",
                 "hub.docker.com"
-            ],
-            "title": "Registry",
-            "type": "string"
+            ]
         },
         "tag": {
+            "type": "string",
+            "title": "Tag",
             "description": "Specifies the version of the image, without colon.",
             "examples": [
                 "latest",
                 "v4.1.2-alpine"
-            ],
-            "title": "Tag",
-            "type": "string"
+            ]
         }
-    },
-    "required": [
-        "name"
-    ],
-    "title": "Schema for container images",
-    "type": "object"
+    }
 }

--- a/labelvalue/v0.0.1.json
+++ b/labelvalue/v0.0.1.json
@@ -1,13 +1,13 @@
 {
     "$id": "https://schema.giantswarm.io/labelvalue/v0.0.1",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "string",
+    "title": "Value of a Kubernetes resource label",
     "examples": [
         "exampleValue",
         "Example_value.with_numbers-and.separators01"
     ],
     "maxLength": 63,
     "minLength": 0,
-    "pattern": "^[-a-zA-Z0-9_\\.]{0,63}$",
-    "title": "Value of a Kubernetes resource label",
-    "type": "string"
+    "pattern": "^[-a-zA-Z0-9_\\.]{0,63}$"
 }


### PR DESCRIPTION
### What does this PR do?

Updates the schemalint version used in CI checks.

The output ordering of `schemalint normalize` has changed in v2, so the ordering of the schema files has to change.

### Are you meeting our versioning requirements?

This is an internal change, not related to the schema content.

### Have you also followed these requirements?

- [x] I have requested reviews from several teams.
- [x] I updated CHANGELOG.md.
- [x] I checked/maintained the README.md within the schema folder.
