### PR TITLE
Add Kubernetes API GVK schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [gvk](gvk/) v0.0.1 (2023-07-07)
+
+- Add gvk schema.
+
 ## 2023-04-23
 
 - CI/CD: Updated schemalint to version v2.1.1.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The purpose is to simplify the building of schemas for [app](https://docs.giants
 
 - [labelvalue](labelvalue/): String to be used as a Kubernetes resource label value.
 
+- [gvk](gvk/): It can be used to specify which CustomResourceDefinition is used.
+
 ## How to use
 
 Schema in this repository can be referenced from other schemas via out `schema.giantswarm.io` resource URLs. Example:

--- a/gvk/v0.0.1.json
+++ b/gvk/v0.0.1.json
@@ -1,41 +1,41 @@
 {
     "$id": "https://schema.giantswarm.io/gvk/v0.0.1",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "type": "object",
-    "title": "Schema for Kubernetes API group, version and kind",
     "description": "It can be used to specify which CustomResourceDefinition is used.",
-    "required": [
-        "group",
-        "version",
-        "kind"
-    ],
     "properties": {
         "group": {
-            "type": "string",
-            "title": "API group",
             "examples": [
                 "cluster.x-k8s.io",
                 "controlplane.cluster.x-k8s.io",
                 "infrastructure.cluster.x-k8s.io"
-            ]
+            ],
+            "title": "API group",
+            "type": "string"
+        },
+        "kind": {
+            "examples": [
+                "Cluster",
+                "KubeadmControlPlane"
+            ],
+            "title": "API kind",
+            "type": "string"
         },
         "version": {
-            "type": "string",
-            "title": "API version",
             "examples": [
                 "v1alpha1",
                 "v1alpha2",
                 "v1beta1",
                 "v1"
-            ]
-        },
-        "kind": {
-            "type": "string",
-            "title": "API kind",
-            "examples": [
-                "Cluster",
-                "KubeadmControlPlane"
-            ]
+            ],
+            "title": "API version",
+            "type": "string"
         }
-    }
+    },
+    "required": [
+        "group",
+        "version",
+        "kind"
+    ],
+    "title": "Schema for Kubernetes API group, version and kind",
+    "type": "object"
 }

--- a/gvk/v0.0.1.json
+++ b/gvk/v0.0.1.json
@@ -1,0 +1,41 @@
+{
+    "$id": "https://schema.giantswarm.io/gvk/v0.0.1",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Schema for Kubernetes API group, version and kind",
+    "description": "It can be used to specify which CustomResourceDefinition is used.",
+    "required": [
+        "group",
+        "version",
+        "kind"
+    ],
+    "properties": {
+        "group": {
+            "type": "string",
+            "title": "API group",
+            "examples": [
+                "cluster.x-k8s.io",
+                "controlplane.cluster.x-k8s.io",
+                "infrastructure.cluster.x-k8s.io"
+            ]
+        },
+        "version": {
+            "type": "string",
+            "title": "API version",
+            "examples": [
+                "v1alpha1",
+                "v1alpha2",
+                "v1beta1",
+                "v1"
+            ]
+        },
+        "kind": {
+            "type": "string",
+            "title": "API kind",
+            "examples": [
+                "Cluster",
+                "KubeadmControlPlane"
+            ]
+        }
+    }
+}

--- a/gvk/v0.0.1.json
+++ b/gvk/v0.0.1.json
@@ -1,41 +1,41 @@
 {
     "$id": "https://schema.giantswarm.io/gvk/v0.0.1",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Schema for Kubernetes API group, version and kind",
     "description": "It can be used to specify which CustomResourceDefinition is used.",
-    "properties": {
-        "group": {
-            "examples": [
-                "cluster.x-k8s.io",
-                "controlplane.cluster.x-k8s.io",
-                "infrastructure.cluster.x-k8s.io"
-            ],
-            "title": "API group",
-            "type": "string"
-        },
-        "kind": {
-            "examples": [
-                "Cluster",
-                "KubeadmControlPlane"
-            ],
-            "title": "API kind",
-            "type": "string"
-        },
-        "version": {
-            "examples": [
-                "v1alpha1",
-                "v1alpha2",
-                "v1beta1",
-                "v1"
-            ],
-            "title": "API version",
-            "type": "string"
-        }
-    },
     "required": [
         "group",
         "version",
         "kind"
     ],
-    "title": "Schema for Kubernetes API group, version and kind",
-    "type": "object"
+    "properties": {
+        "group": {
+            "type": "string",
+            "title": "API group",
+            "examples": [
+                "cluster.x-k8s.io",
+                "controlplane.cluster.x-k8s.io",
+                "infrastructure.cluster.x-k8s.io"
+            ]
+        },
+        "kind": {
+            "type": "string",
+            "title": "API kind",
+            "examples": [
+                "Cluster",
+                "KubeadmControlPlane"
+            ]
+        },
+        "version": {
+            "type": "string",
+            "title": "API version",
+            "examples": [
+                "v1alpha1",
+                "v1alpha2",
+                "v1beta1",
+                "v1"
+            ]
+        }
+    }
 }


### PR DESCRIPTION
### What does this PR do?

(Please set a descriptive PR title. Use this space for additional explanations.)

First use case for this is when one resource references another one (e.g. `Cluster` resource has `spec.infrastructureRef` which references `AWSCluster` version `v1beta1` from API group `infrastructure.cluster.x-k8s.io`), and that is configurable (e.g. in previous example different providers have different values, or the provider is updated to a newer version), so with this we can specify group, version and kind.

### Any background context you can provide?

Working on restructuring of cluster apps. Many parts of the schema there can be reused across cluster apps and in many other places.

### Are you meeting our versioning requirements?

- In general, all schema modifications are done by creating a new version and new file.
- Changes that can lead to breaking validation (where the payload was valid with the previous version) require a **major** version bump.
- Non-breaking changes like additions should yield a new **minor** version.
- Only smallest changes should be published as **patch** version bump, e. g. a typo fix in a `title` or `description` field.

### Have you also followed these requirements?

- [x] I have requested reviews from several teams.
- [x] I updated CHANGELOG.md.
- [x] I checked/maintained the README.md within the schema folder.
