### PR TITLE
Renovate: enable schemalint upgrade, pin GitHub actions to SHA

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,5 +2,7 @@
   "extends": [
     // Base config - https://github.com/giantswarm/renovate-presets/blob/main/default.json5
     "github>giantswarm/renovate-presets:default.json5",
+    // Pin to the SHA of a GitHub action.
+    "helpers:pinGitHubActionDigests",
   ],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -5,4 +5,13 @@
     // Pin to the SHA of a GitHub action.
     "helpers:pinGitHubActionDigests",
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^lint\\.yaml$"],
+      "matchStrings": ["SCHEMALINT_VERSION: (?<currentValue>.*?)\\n"],
+      "depNameTemplate": "giantswarm/schemalint",
+      "datasourceTemplate": "github-releases"
+    },
+  ]
 }


### PR DESCRIPTION
### What does this PR do?

- Enables updating schemalint
- Enables version pinning of GitHub actions by SHA in the Renovate config.